### PR TITLE
fix(#9): fix install script exiting after first file download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,10 +114,10 @@ fail_count=0
 for file in "${COMMAND_FILES[@]}"; do
     if curl -fsSL "${REPO_RAW_URL}/commands/${file}" -o "${SHEEP_DIR}/${file}" 2>/dev/null; then
         echo "  ✓ $file"
-        ((success_count++))
+        success_count=$((success_count + 1))
     else
         echo "  ✗ $file (failed)"
-        ((fail_count++))
+        fail_count=$((fail_count + 1))
     fi
 done
 


### PR DESCRIPTION
The ((var++)) syntax returns 0 when var is 0, which set -e treats as an error. Using var=$((var + 1)) instead always succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal script syntax for improved compatibility and maintainability. No impact to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->