### PR TITLE
fix: improve /sheep:review PR handling

### DIFF
--- a/commands/review.md
+++ b/commands/review.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash(gh pr view *)
   - Bash(gh pr diff *)
   - Bash(gh pr checks *)
+  - Bash(gh pr checkout *)
   - Bash(gh pr review *)
   - Bash(gh issue view *)
   - Bash(gh api repos/*/pulls/*/comments*)
@@ -220,14 +221,18 @@ Options:
 
 **If user chooses to fix:**
 
-1. Read the affected files
-2. Apply fixes based on error analysis
-3. Commit with message: `fix(#issue): resolve CI errors - [description]`
-4. Push to PR branch
-5. Wait for CI to re-run (or continue review)
+1. **Checkout the PR branch** (don't create a new branch!)
+2. Read the affected files
+3. Apply fixes based on error analysis
+4. Commit with message: `fix(#issue): resolve CI errors - [description]`
+5. Push to PR branch
+6. Wait for CI to re-run (or continue review)
 
 ```bash
-# After fixing, push to the PR branch
+# IMPORTANT: Checkout the existing PR branch (don't create a new branch!)
+gh pr checkout 45
+
+# After fixing, push to the PR branch (this updates the PR)
 git push origin HEAD
 ```
 </step>
@@ -364,12 +369,20 @@ Options:
 ```
 
 If user chooses "Fix CI errors":
-1. Checkout the PR branch locally
+1. **Checkout the PR branch locally** (don't create a new branch!)
 2. Analyze the error logs from `gh run view --log-failed`
 3. Read and fix the affected files
 4. Commit: `fix(#issue): resolve CI errors`
-5. Push to PR branch
+5. Push to PR branch (this updates the PR)
 6. Continue with review (or wait for CI to re-run)
+
+```bash
+# IMPORTANT: Checkout the existing PR branch (don't create a new branch!)
+gh pr checkout 45
+
+# After making fixes and committing...
+git push origin HEAD
+```
 </step>
 
 <step name="submit-review">


### PR DESCRIPTION
## Summary

Two important fixes to the `/sheep:review` command:

1. **Capture PR conversation comments** - The review command now fetches PR conversation comments (general discussion on the PR), not just inline code comments and formal reviews
2. **Checkout existing PR branch** - When fixing CI errors, the agent now explicitly checks out the existing PR branch using `gh pr checkout`, instead of potentially creating a new branch

## Changes

### Fix 1: PR Conversation Comments
- Added `gh pr view --json comments` to fetch PR conversation
- Updated feedback categorization to include conversation as first category
- This captures automated bot comments, casual contributor comments, and general discussion

### Fix 2: Branch Handling
- Added `gh pr checkout` to allowed-tools
- Added explicit bash commands showing `gh pr checkout <PR_NUMBER>` usage
- Added warnings emphasizing "don't create a new branch!"
- Clarified that `git push origin HEAD` updates the existing PR

## Why These Matter

**Conversation Comments:**
- Open source projects often have casual comments in the conversation tab
- CI bots and security scanners post there
- General actionable feedback may be missed without this

**Branch Handling:**
- Creating a new branch when reviewing an open PR is pointless
- Fixes need to go to the existing PR branch to update the PR
- This prevents confusion and wasted work

## Test Plan

- [ ] Run `/sheep:review` on an open PR with conversation comments
- [ ] Verify conversation comments are captured and analyzed
- [ ] Choose to fix CI errors
- [ ] Verify agent runs `gh pr checkout <PR_NUMBER>`
- [ ] Verify fixes are pushed to the existing PR branch
- [ ] Verify the PR is updated with the fixes

🐑 Generated with Sheep It