### PR TITLE
fix: Prevent namespace leakage between Sheep It and OpenSpec

### DIFF
--- a/commands/it.md
+++ b/commands/it.md
@@ -235,6 +235,14 @@ OpenSpec validates:
 - Correctness (implementation matches specs)
 - Design coherence (follows technical design)
 
+**After adapter verify completes, show:**
+```
+🔌 OpenSpec verification complete
+
+✓ Implementation verified
+→ Continuing to archive step...
+```
+
 **4. If no adapter or no verify mapping:**
 
 Skip verification - proceed to archive.
@@ -273,6 +281,16 @@ args: "{issue number or PR context}"
 ```
 
 The adapter handles any cleanup, archiving, or finalization needed.
+
+**After adapter archive completes, show:**
+```
+🔌 OpenSpec archive complete
+
+✓ Spec files archived/cleaned up
+→ Continuing Sheep It workflow: Creating PR...
+
+Note: PR will be created next - stay in Sheep It flow
+```
 
 **4. If no adapter or no archive mapping:**
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -494,6 +494,19 @@ args: "{issue number or context}"
 The adapter will take over the implementation. When it completes,
 Sheep It will continue with verification and completion steps.
 
+**After adapter completes, show:**
+```
+🔌 OpenSpec implementation complete
+
+✓ Code implemented and committed
+→ Continuing Sheep It workflow...
+
+Next: /sheep:verify (to check acceptance criteria)
+      or /sheep:it (to ship the PR)
+
+Note: Stay in Sheep It namespace - don't use /opsx:verify
+```
+
 **5. If no adapter or adapter disabled:**
 
 Continue with the normal sheep:start implementation flow.

--- a/commands/task.md
+++ b/commands/task.md
@@ -73,6 +73,15 @@ args: "{user's task description}"
 OpenSpec will run: `opsx:new` → `opsx:ff` internally.
 After completion, extract the spec and continue to create GitHub issue.
 
+**After OpenSpec completes, show:**
+```
+⚡ OpenSpec spec generation complete
+
+→ Continuing Sheep It workflow: Creating GitHub issue from spec...
+
+Note: When the issue is created, continue with /sheep:start (not /opsx:apply)
+```
+
 **5. Deep mode (--deep flag) with adapter:**
 
 Continue to the existing `deep-research` step below, but also use OpenSpec:
@@ -91,6 +100,15 @@ args: "{user's task description}"
 
 After exploration, OpenSpec will chain to `opsx:new` → `opsx:continue`.
 Extract the spec and continue to create GitHub issue.
+
+**After OpenSpec completes, show:**
+```
+🔬 OpenSpec exploration complete
+
+→ Continuing Sheep It workflow: Creating GitHub issue from research...
+
+Note: When the issue is created, continue with /sheep:start (not /opsx:apply)
+```
 
 **6. If no adapter or adapter disabled:**
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -70,6 +70,19 @@ OpenSpec validates:
 - **Correctness**: Implementation matches specs and requirements
 - **Design coherence**: Follows technical design patterns
 
+**After adapter completes, show:**
+```
+🔌 OpenSpec verification complete
+
+✓ All acceptance criteria verified
+✓ Implementation matches specs
+→ Continuing Sheep It workflow...
+
+Next: /sheep:it (to create the PR and ship)
+
+Note: Stay in Sheep It namespace - verification is done
+```
+
 **4. If no adapter or adapter disabled:**
 
 Continue with manual Sheep It verification (get-criteria step).


### PR DESCRIPTION
## Problem

When users start a workflow with Sheep It commands (`/sheep:task`, `/sheep:start`, etc.), the OpenSpec adapter would complete and suggest OpenSpec commands (`/opsx:apply`, `/opsx:verify`, etc.) as the next step. This broke the user experience and caused confusion about which command namespace to use.

**Example of the issue:**
```
User: /sheep:task "Add payments"
OpenSpec: [creates spec]
OpenSpec: "Next: Run /opsx:apply"  ❌ Wrong! Should suggest /sheep:start
```

## Solution

Added clear continuation messages after each adapter delegation point to ensure users stay in the correct command namespace throughout their workflow.

**Design principle:** If you start with `/sheep:*`, stay in Sheep It namespace. If you start with `/opsx:*`, stay in OpenSpec namespace. No jumping between flows mid-workflow.

## Changes

### task.md
- After `opsx:ff` completes → clarify to use `/sheep:start` next (not `/opsx:apply`)
- After `opsx:explore` completes → clarify to use `/sheep:start` next

### start.md  
- After `opsx:apply` completes → clarify to use `/sheep:verify` or `/sheep:it` next (not `/opsx:verify`)

### verify.md
- After `opsx:verify` completes → clarify to use `/sheep:it` next (not continuing OpenSpec flow)

### it.md
- After `opsx:verify` completes → clarify continuing to archive step
- After `opsx:archive` completes → clarify PR creation flow

## User Experience Improvement

**Before:**
```
/sheep:task → OpenSpec runs → suggests /opsx:apply → user confused 😕
```

**After:**
```
/sheep:task → OpenSpec runs → "✅ Complete. Next: /sheep:start" → user stays in flow ✨
```

## Testing

Manually verify that:
- [ ] `/sheep:task` → `/sheep:start` flow is clear
- [ ] `/sheep:start` → `/sheep:verify` or `/sheep:it` flow is clear
- [ ] `/sheep:verify` → `/sheep:it` flow is clear
- [ ] OpenSpec commands still work independently when called directly

🐑 Generated with Sheep It workflow orchestrator